### PR TITLE
Migrate off pkg_resources to importlib (v0.0.11)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.0.11
+
+### Changed
+- Migrate off `pkg_resources` (removed in setuptools 81) to `importlib.resources`
+  for loading the bundled CSV metadata (`methods.csv`, `stop_reasons.csv`, `flags.csv`).
+
+No other functional changes since 0.0.10.

--- a/libgeosuitesnd/__init__.py
+++ b/libgeosuitesnd/__init__.py
@@ -10,7 +10,7 @@ import codecs
 import os
 import io
 import logging
-import pkg_resources
+from importlib.resources import files
 
 logger = logging.getLogger(__name__)
 
@@ -21,13 +21,13 @@ def _read_csv(f):
     return pd.read_csv(f, na_values=na_values, keep_default_na=False).set_index("code")
 
 
-with pkg_resources.resource_stream("libgeosuitesnd", "methods.csv") as f:
+with files("libgeosuitesnd").joinpath("methods.csv").open("rb") as f:
     methods = _read_csv(f)
     method_by_code = methods["name"]
-with pkg_resources.resource_stream("libgeosuitesnd", "stop_reasons.csv") as f:
+with files("libgeosuitesnd").joinpath("stop_reasons.csv").open("rb") as f:
     stop_reasons = _read_csv(f)
     stop_reason_by_code = stop_reasons["name"]
-with pkg_resources.resource_stream("libgeosuitesnd", "flags.csv") as f:
+with files("libgeosuitesnd").joinpath("flags.csv").open("rb") as f:
     flags = _read_csv(f)
 
 snd_columns_by_method = {key: value.split(",") for key, value in methods["columns"].to_dict().items() if isinstance(value, str)}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 
 setuptools.setup(
     name='libgeosuitesnd',
-    version='0.0.10',
+    version='0.0.11',
     description='Parser for the GeoSuite<tm> SND export format',
     long_description="""Parser for the GeoSuite<tm> SND export format""",
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Part of emerald-geomodelling/emerald-installer#19. Replaces `pkg_resources.resource_stream` with `importlib.resources.files(...).open('rb')` (binary stream, verified drop-in equivalent). Version bump to 0.0.11 + CHANGES. setuptools>=81 dropped pkg_resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)