### PR TITLE
Fix pandas 3.0 incompatibility in parse_string_data_column

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.0.12
+
+### Fixed
+- pandas 3.0 compatibility in `parse_string_data_column`: replace the deprecated
+  `Series.replace(to_replace=-1, method='ffill', inplace=True)` (which also relied
+  on chained-assignment that silently no-ops under Copy-on-Write) with
+  `df_data[flag] = df_data[flag].replace(-1, np.nan).ffill()` followed by filling
+  the remaining leading sentinels with 0. Removes two `FutureWarning`s and preserves
+  the original forward-fill-over-sentinel behaviour.
+
 ## 0.0.11
 
 ### Changed

--- a/libgeosuitesnd/__init__.py
+++ b/libgeosuitesnd/__init__.py
@@ -108,8 +108,8 @@ def parse_string_data_column(df_data, raw_data_nestedlist,n_data_col):
 
     for flag in flags["name"].unique():
         if flag != "depth_bedrock":
-            df_data[flag].replace(to_replace=-1, method='ffill', inplace=True)
-            df_data.loc[df_data[flag] == -1, flag] = 0
+            df_data[flag] = df_data[flag].replace(-1, np.nan).ffill()
+            df_data.loc[df_data[flag].isna(), flag] = 0
     
     return df_data, depth_bedrock
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 
 setuptools.setup(
     name='libgeosuitesnd',
-    version='0.0.11',
+    version='0.0.12',
     description='Parser for the GeoSuite<tm> SND export format',
     long_description="""Parser for the GeoSuite<tm> SND export format""",
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Closes #9. Part of emerald-geomodelling/emerald-installer#23 (pandas 3.0 forward-port).

## What

Replaces the deprecated `Series.replace(to_replace=-1, method='ffill', inplace=True)` in `parse_string_data_column` with:

```python
df_data[flag] = df_data[flag].replace(-1, np.nan).ffill()
df_data.loc[df_data[flag].isna(), flag] = 0
```

## Why

The old call emitted two `FutureWarning`s and breaks under pandas 3.0:

- the `method` keyword in `Series.replace` is removed in pandas 3.0 (fill-direction must move to `.ffill()`);
- `df_data[flag].replace(..., inplace=True)` is chained assignment on a copy, which becomes a silent no-op under mandatory Copy-on-Write.

These showed up as many repeated warnings in the project-24048 Gjøvik SND-parsing pipeline output.

## Behaviour

Unchanged: `-1` sentinels are forward-filled from the last real value; remaining leading sentinels become `0`. Verified equivalent on pandas 2.3.3 across leading / interior / trailing / all-sentinel / no-sentinel inputs, with no FutureWarning emitted.

Minor: the flag column is now float-typed (NaN intermediate) — harmless for these numeric flags.

## Other

- Bumps version `0.0.11` → `0.0.12` and adds a `CHANGES.md` entry.
- The 0.18.1 DEV venvs install this non-editable, so they need a reinstall to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)